### PR TITLE
chore: Updated dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "neon-JS"
+      - "niklas-schmidt-traperto"


### PR DESCRIPTION
I don't want to use my private account for a company repository. Therefore I set my company account as the default reviewer. We'll see whether I'll be responsible for the updates in a long run.