### PR TITLE
fix: Skip parent types if child matches too

### DIFF
--- a/MagicBytesValidator.CLI/Program.cs
+++ b/MagicBytesValidator.CLI/Program.cs
@@ -18,21 +18,28 @@ public class Program
                .GetResult()
                .ToList();
 
+            var closestMatches = streamFileTypeProvider
+                .FindCloseMatchesAsync(file, CancellationToken.None)
+                .GetAwaiter()
+                .GetResult()
+                .ToList();
+
             if (matches.Count == 0)
             {
                 Console.WriteLine("No matches.");
                 return;
             }
 
-            Console.WriteLine($"{"FileType",-10}| {"Extensions",-40}| {"MIME Types",-80}");
-            Console.WriteLine(new string('-', 130));
+            Console.WriteLine($"{"FileType",-10}| {"Extensions",-40}| {"MIME Types",-80}| {"Indirect",-8}");
+            Console.WriteLine(new string('-', 145));
 
             foreach (var match in matches)
             {
                 var mimeTypeList = string.Join(", ", match.MimeTypes);
                 var extensionList = string.Join(", ", match.Extensions);
+                var indirect = closestMatches.All(c => c.GetType() != match.GetType()) ? "Yes" : string.Empty;
 
-                Console.WriteLine($"{match.GetType().Name,-10}| {extensionList,-40}| {mimeTypeList,-80}");
+                Console.WriteLine($"{match.GetType().Name,-10}| {extensionList,-40}| {mimeTypeList,-80}| {indirect,-8}");
             }
 
             Console.WriteLine();

--- a/MagicBytesValidator.Tests/MappingRegister.cs
+++ b/MagicBytesValidator.Tests/MappingRegister.cs
@@ -4,7 +4,7 @@ public class MappingRegister
 {
     private readonly Mapping _mapping = new();
 
-    private readonly IFileType _trpFileType = new FileByteFilter(
+    private readonly IFileType _trpFileType = new TestFileType(
         ["traperto/trp"],
         ["trp"]
     ).StartsWith([0x74, 0x72, 0x61, 0x70, 0x65, 0x72, 0x74, 0x6f]);
@@ -19,17 +19,17 @@ public class MappingRegister
     [Fact]
     public void Should_register_list_filetype()
     {
-        var cusDbcLaikaFileType = new FileByteFilter(
+        var cusDbcLaikaFileType = new TestFileType(
             ["traperto/laikaschmidt"],
-            ["nms"]
+            ["ls"]
         ).StartsWith([0x6e, 0x69, 0x6b, 0x6c, 0x61, 0x73, 0x73, 0x63, 0x68, 0x6d, 0x69, 0x64, 0x74]);
 
-        var kryptobiFileType = new FileByteFilter(
+        var kryptobiFileType = new TestFileType(
             ["traperto/tobiasjanssen"],
             ["tjn"]
         ).StartsWith([0x74, 0x6f, 0x62, 0x69, 0x61, 0x73, 0x6a, 0x61, 0x6e, 0x73, 0x73, 0x65, 0x6e]);
 
-        _mapping.Register(new[] { cusDbcLaikaFileType, kryptobiFileType });
+        _mapping.Register([cusDbcLaikaFileType, kryptobiFileType]);
         Assert.Contains(kryptobiFileType, _mapping.FileTypes);
         Assert.Contains(cusDbcLaikaFileType, _mapping.FileTypes);
     }

--- a/MagicBytesValidator.Tests/Streams/FindAllMatchesAsync.cs
+++ b/MagicBytesValidator.Tests/Streams/FindAllMatchesAsync.cs
@@ -5,31 +5,27 @@ public class FindAllMatchesAsync
     [Fact]
     public async Task Should_find_all_by_magic_byte_sequence()
     {
-        var matchingFileType1 = new FileByteFilter(
-            ["matching"],
-            ["mtch"]
-        ).StartsWithAnyOf([
-            [0x11, 0x12, 0x19, 0x20],
-            [0x11, 0x12, 0x18],
-            [0x11, 0x12],
-        ]);
+        var matchingFileType1 = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x12, 0x19, 0x20],
+                [0x11, 0x12, 0x18],
+                [0x11, 0x12],
+            ]);
 
-        var matchingFileType2 = new FileByteFilter(
-            ["also/matching"],
-            ["mtch2"]
-        ).StartsWithAnyOf([
-            [0x11, 0x12],
-            [0x11, 0x22, 0x44, 0x55]
-        ]);
+        var matchingFileType2 = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x12],
+                [0x11, 0x22, 0x44, 0x55]
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(new[] { matchingFileType1, matchingFileType2 });
+           .Returns([matchingFileType1, matchingFileType2]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x11, 0x12, 0x18 });
+        var stream = new MemoryStream([0x11, 0x12, 0x18]);
 
         var result = (await sut.FindAllMatchesAsync(stream, CancellationToken.None))
            .ToList();
@@ -42,23 +38,21 @@ public class FindAllMatchesAsync
     [Fact]
     public async Task Should_reset_stream_position()
     {
-        var matchingFileType = new FileByteFilter(
-            ["matching"],
-            ["mtch"]
-        ).StartsWithAnyOf([
-            [0x11, 0x12, 0x19, 0x20],
-            [0x11, 0x12, 0x18],
-            [0x11, 0x12],
-        ]);
+        var matchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x12, 0x19, 0x20],
+                [0x11, 0x12, 0x18],
+                [0x11, 0x12],
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(new[] { matchingFileType });
+           .Returns([matchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x11, 0x12, 0x18 })
+        var stream = new MemoryStream([0x11, 0x12, 0x18])
         {
             Position = 1
         };
@@ -71,22 +65,20 @@ public class FindAllMatchesAsync
     [Fact]
     public async Task Should_handle_unknown_file_type()
     {
-        var mismatchingFileType = new FileByteFilter(
-            ["mismatching"],
-            ["mism"]
-        ).StartsWithAnyOf([
-            [0x11, 0x22],
-            [0x11, 0x22, 0x44, 0x55]
-        ]);
+        var mismatchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x22],
+                [0x11, 0x22, 0x44, 0x55]
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(new[] { mismatchingFileType });
+           .Returns([mismatchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x12, 0x11 });
+        var stream = new MemoryStream([0x12, 0x11]);
 
         var result = await sut.FindAllMatchesAsync(stream, CancellationToken.None);
 
@@ -99,11 +91,11 @@ public class FindAllMatchesAsync
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(Array.Empty<IFileType>());
+           .Returns([]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x12, 0x11 });
+        var stream = new MemoryStream([0x12, 0x11]);
 
         var result = await sut.FindAllMatchesAsync(stream, CancellationToken.None);
 
@@ -116,7 +108,7 @@ public class FindAllMatchesAsync
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(Array.Empty<IFileType>());
+           .Returns([]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 

--- a/MagicBytesValidator.Tests/Streams/FindByMagicByteSequenceAsync.cs
+++ b/MagicBytesValidator.Tests/Streams/FindByMagicByteSequenceAsync.cs
@@ -7,31 +7,27 @@ public class FindByMagicByteSequenceAsync
     [Fact]
     public async Task Should_find_by_magic_byte_sequence()
     {
-        var matchingFileType = new FileByteFilter(
-            ["matching"],
-            ["mtch"]
-        ).StartsWithAnyOf([
-            [0x11, 0x12, 0x19, 0x20],
-            [0x11, 0x12, 0x18],
-            [0x11, 0x12],
-        ]);
+        var matchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x12, 0x19, 0x20],
+                [0x11, 0x12, 0x18],
+                [0x11, 0x12],
+            ]);
 
-        var mismatchingFileType = new FileByteFilter(
-            ["mismatching"],
-            ["mism"]
-        ).StartsWithAnyOf([
-            [0x11, 0x22],
-            [0x11, 0x22, 0x44, 0x55]
-        ]);
+        var mismatchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x22],
+                [0x11, 0x22, 0x44, 0x55]
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(new[] { matchingFileType, mismatchingFileType });
+           .Returns([matchingFileType, mismatchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x11, 0x12, 0x18 });
+        var stream = new MemoryStream([0x11, 0x12, 0x18]);
 
         var result = await sut.FindByMagicByteSequenceAsync(stream, CancellationToken.None);
 
@@ -42,23 +38,21 @@ public class FindByMagicByteSequenceAsync
     [Fact]
     public async Task Should_reset_stream_position()
     {
-        var matchingFileType = new FileByteFilter(
-            ["matching"],
-            ["mtch"]
-        ).StartsWithAnyOf([
-            [0x11, 0x12, 0x19, 0x20],
-            [0x11, 0x12, 0x18],
-            [0x11, 0x12],
-        ]);
+        var matchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x12, 0x19, 0x20],
+                [0x11, 0x12, 0x18],
+                [0x11, 0x12],
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(new[] { matchingFileType });
+           .Returns([matchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x11, 0x12, 0x18 })
+        var stream = new MemoryStream([0x11, 0x12, 0x18])
         {
             Position = 1
         };
@@ -72,22 +66,20 @@ public class FindByMagicByteSequenceAsync
     [Fact]
     public async Task Should_handle_unknown_file_type()
     {
-        var mismatchingFileType = new FileByteFilter(
-            ["mismatching"],
-            ["mism"]
-        ).StartsWithAnyOf([
-            [0x11, 0x22],
-            [0x11, 0x22, 0x44, 0x55]
-        ]);
+        var mismatchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x22],
+                [0x11, 0x22, 0x44, 0x55]
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(new[] { mismatchingFileType });
+           .Returns([mismatchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x12, 0x11 });
+        var stream = new MemoryStream([0x12, 0x11]);
 
         var result = await sut.FindByMagicByteSequenceAsync(stream, CancellationToken.None);
 
@@ -100,11 +92,11 @@ public class FindByMagicByteSequenceAsync
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(Array.Empty<IFileType>());
+           .Returns([]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x12, 0x11 });
+        var stream = new MemoryStream([0x12, 0x11]);
 
         var result = await sut.FindByMagicByteSequenceAsync(stream, CancellationToken.None);
 
@@ -117,7 +109,7 @@ public class FindByMagicByteSequenceAsync
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(Array.Empty<IFileType>());
+           .Returns([]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
@@ -129,27 +121,23 @@ public class FindByMagicByteSequenceAsync
     [Fact]
     public async Task Should_find_by_magic_byte_sequence_with_offset()
     {
-        var matchingFileType = new FileByteFilter(
-            ["matching"],
-            ["mtch"]
-        ).Anywhere([0x11, 0x12, 0x18]);
+        var matchingFileType = new TestFileType()
+            .Anywhere([0x11, 0x12, 0x18]);
 
-        var mismatchingFileType = new FileByteFilter(
-            ["mismatching"],
-            ["mism"]
-        ).StartsWithAnyOf([
-            [0x11, 0x22, 0xFF],
-            [0x11, 0x22, 0x44, 0x55]
-        ]);
+        var mismatchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x22, 0xFF],
+                [0x11, 0x22, 0x44, 0x55]
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(new[] { matchingFileType, mismatchingFileType });
+           .Returns([matchingFileType, mismatchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x00, 0x00, 0x11, 0x12, 0x18 });
+        var stream = new MemoryStream([0x00, 0x00, 0x11, 0x12, 0x18]);
 
         var result = await sut.FindByMagicByteSequenceAsync(stream, CancellationToken.None);
 
@@ -160,21 +148,19 @@ public class FindByMagicByteSequenceAsync
     [Fact]
     public async Task Should_handle_unknown_file_type_by_offset_in_type()
     {
-        var mismatchingFileType = new FileByteFilter(
-            ["mismatching"],
-            ["mism"]
-        ).StartsWithAnyOf([
-            [0x11, 0x22, 0x44, 0x55]
-        ]);
+        var mismatchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x22, 0x44, 0x55]
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(new[] { mismatchingFileType });
+           .Returns([mismatchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x11, 0x22 });
+        var stream = new MemoryStream([0x11, 0x22]);
 
         var result = await sut.FindByMagicByteSequenceAsync(stream, CancellationToken.None);
 
@@ -184,22 +170,20 @@ public class FindByMagicByteSequenceAsync
     [Fact]
     public async Task Should_handle_unknown_file_type_by_offset_in_stream()
     {
-        var mismatchingFileType = new FileByteFilter(
-            ["mismatching"],
-            ["mism"]
-        ).StartsWithAnyOf([
-            [0x11, 0x22],
-            [0x11, 0x22, 0x44, 0x55]
-        ]);
+        var mismatchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x22],
+                [0x11, 0x22, 0x44, 0x55]
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
            .SetupGet(m => m.FileTypes)
-           .Returns(new[] { mismatchingFileType });
+           .Returns([mismatchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x00, 0x00, 0x11, 0x22 });
+        var stream = new MemoryStream([0x00, 0x00, 0x11, 0x22]);
 
         var result = await sut.FindByMagicByteSequenceAsync(stream, CancellationToken.None);
 

--- a/MagicBytesValidator.Tests/Streams/FindCloseMatchesAsync.cs
+++ b/MagicBytesValidator.Tests/Streams/FindCloseMatchesAsync.cs
@@ -1,0 +1,61 @@
+﻿namespace MagicBytesValidator.Tests.Streams;
+
+public class FindCloseMatchesAsync
+{
+    [Fact]
+    public async Task Should_skip_parent_types()
+    {
+        var parentFileType = new ParentFileType();
+        var childFileType = new ChildFileType();
+        var unrelatedFileType = new TestFileType()
+            .Anywhere([3, 4, 5]);
+
+        var mapping = new Mock<IMapping>();
+        mapping
+            .SetupGet(m => m.FileTypes)
+            .Returns([
+                unrelatedFileType,
+                parentFileType,
+                childFileType,
+            ]);
+
+        var sut = new StreamFileTypeProvider(mapping.Object);
+
+        /* Matches both parent and child file type -> result should only include child */
+        var stream = new MemoryStream([1, 2, 3, 4, 5, 6]);
+
+        var result = (await sut.FindCloseMatchesAsync(stream, CancellationToken.None)).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(childFileType, result);
+        Assert.Contains(unrelatedFileType, result);
+    }
+
+    [Fact]
+    public async Task Should_work_with_multiple_layers()
+    {
+        var parentFileType = new ParentFileType();
+        var childFileType = new ChildFileType();
+        var grandchildFileType = new GrandchildFileType();
+
+        var mapping = new Mock<IMapping>();
+        mapping
+            .SetupGet(m => m.FileTypes)
+            .Returns([
+                grandchildFileType,
+                childFileType,
+                parentFileType,
+            ]);
+
+        var sut = new StreamFileTypeProvider(mapping.Object);
+
+        /* Matches parent, child and grandchild file type -> result should only include grandchild */
+        var stream = new MemoryStream([1, 2, 3, 10, 11, 12, 4, 5, 6]);
+
+        var result = (await sut.FindCloseMatchesAsync(stream, CancellationToken.None)).ToList();
+
+        Assert.Single(result);
+        Assert.Contains(grandchildFileType, result);
+    }
+}
+

--- a/MagicBytesValidator.Tests/Streams/TryFindUnambiguousAsync.cs
+++ b/MagicBytesValidator.Tests/Streams/TryFindUnambiguousAsync.cs
@@ -5,31 +5,27 @@ public class TryFindUnambiguousAsync
     [Fact]
     public async Task Should_find_by_magic_byte_sequence()
     {
-        var matchingFileType = new FileByteFilter(
-            ["matching"],
-            ["mtch"]
-        ).StartsWithAnyOf([
-            [0x11, 0x12, 0x19, 0x20],
-            [0x11, 0x12, 0x18],
-            [0x11, 0x12],
-        ]);
+        var matchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x12, 0x19, 0x20],
+                [0x11, 0x12, 0x18],
+                [0x11, 0x12],
+            ]);
 
-        var mismatchingFileType = new FileByteFilter(
-            ["mismatching"],
-            ["mism"]
-        ).StartsWithAnyOf([
-            [0x11, 0x22],
-            [0x11, 0x22, 0x44, 0x55]
-        ]);
+        var mismatchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x22],
+                [0x11, 0x22, 0x44, 0x55]
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
             .SetupGet(m => m.FileTypes)
-            .Returns(new[] { matchingFileType, mismatchingFileType });
+            .Returns([matchingFileType, mismatchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x11, 0x12, 0x18 });
+        var stream = new MemoryStream([0x11, 0x12, 0x18]);
 
         var result = await sut.TryFindUnambiguousAsync(stream, CancellationToken.None);
 
@@ -40,23 +36,21 @@ public class TryFindUnambiguousAsync
     [Fact]
     public async Task Should_reset_stream_position()
     {
-        var matchingFileType = new FileByteFilter(
-            ["matching"],
-            ["mtch"]
-        ).StartsWithAnyOf([
-            [0x11, 0x12, 0x19, 0x20],
-            [0x11, 0x12, 0x18],
-            [0x11, 0x12],
-        ]);
+        var matchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x12, 0x19, 0x20],
+                [0x11, 0x12, 0x18],
+                [0x11, 0x12],
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
             .SetupGet(m => m.FileTypes)
-            .Returns(new[] { matchingFileType });
+            .Returns([matchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x11, 0x12, 0x18 })
+        var stream = new MemoryStream([0x11, 0x12, 0x18])
         {
             Position = 1
         };
@@ -70,22 +64,20 @@ public class TryFindUnambiguousAsync
     [Fact]
     public async Task Should_handle_unknown_file_type()
     {
-        var mismatchingFileType = new FileByteFilter(
-            ["mismatching"],
-            ["mism"]
-        ).StartsWithAnyOf([
-            [0x11, 0x22],
-            [0x11, 0x22, 0x44, 0x55]
-        ]);
+        var mismatchingFileType = new TestFileType()
+            .StartsWithAnyOf([
+                [0x11, 0x22],
+                [0x11, 0x22, 0x44, 0x55]
+            ]);
 
         var mapping = new Mock<IMapping>();
         mapping
             .SetupGet(m => m.FileTypes)
-            .Returns(new[] { mismatchingFileType });
+            .Returns([mismatchingFileType]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x12, 0x11 });
+        var stream = new MemoryStream([0x12, 0x11]);
 
         var result = await sut.TryFindUnambiguousAsync(stream, CancellationToken.None);
 
@@ -98,11 +90,11 @@ public class TryFindUnambiguousAsync
         var mapping = new Mock<IMapping>();
         mapping
             .SetupGet(m => m.FileTypes)
-            .Returns(Array.Empty<IFileType>());
+            .Returns([]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
-        var stream = new MemoryStream(new byte[] { 0x12, 0x11 });
+        var stream = new MemoryStream([0x12, 0x11]);
 
         var result = await sut.TryFindUnambiguousAsync(stream, CancellationToken.None);
 
@@ -115,12 +107,36 @@ public class TryFindUnambiguousAsync
         var mapping = new Mock<IMapping>();
         mapping
             .SetupGet(m => m.FileTypes)
-            .Returns(Array.Empty<IFileType>());
+            .Returns([]);
 
         var sut = new StreamFileTypeProvider(mapping.Object);
 
         await Assert.ThrowsAsync<ArgumentNullException>(
             async () => await sut.TryFindUnambiguousAsync(null!, CancellationToken.None)
         );
+    }
+
+    [Fact]
+    public async Task Should_use_closest_types()
+    {
+        var parentFileType = new ParentFileType();
+        var childFileType = new ChildFileType();
+
+        var mapping = new Mock<IMapping>();
+        mapping
+            .SetupGet(m => m.FileTypes)
+            .Returns([
+                parentFileType,
+                childFileType,
+            ]);
+
+        var sut = new StreamFileTypeProvider(mapping.Object);
+
+        /* Matches both parent and child file type -> result should only include child */
+        var stream = new MemoryStream([1, 2, 3, 4, 5, 6]);
+
+        var result = await sut.TryFindUnambiguousAsync(stream, CancellationToken.None);
+
+        Assert.Same(childFileType, result);
     }
 }

--- a/MagicBytesValidator.Tests/TestFileTypes.cs
+++ b/MagicBytesValidator.Tests/TestFileTypes.cs
@@ -1,0 +1,47 @@
+namespace MagicBytesValidator.Tests;
+
+public class TestFileType : FileByteFilter
+{
+    public TestFileType(string[] mimeTypes, string[] extensions) : base(mimeTypes, extensions)
+    {
+    }
+
+    public TestFileType() : this([Guid.NewGuid().ToString()], [Guid.NewGuid().ToString()])
+    {
+
+    }
+}
+
+class ParentFileType : FileByteFilter
+{
+
+    public ParentFileType() : this(["parent"], ["parent"])
+    {
+    }
+
+    public ParentFileType(string[] mimeTypes, string[] extensions) : base(mimeTypes, extensions)
+    {
+        StartsWith([1, 2, 3]);
+    }
+}
+
+class ChildFileType : ParentFileType
+{
+
+    public ChildFileType() : this(["child"], ["child"])
+    {
+    }
+
+    public ChildFileType(string[] mimeTypes, string[] extensions) : base(mimeTypes, extensions)
+    {
+        EndsWith([4, 5, 6]);
+    }
+}
+
+class GrandchildFileType : ChildFileType
+{
+    public GrandchildFileType() : base(["grandchild"], ["grandchild"])
+    {
+        Anywhere([10, 11, 12]);
+    }
+}

--- a/MagicBytesValidator/Models/FileByteFilter.cs
+++ b/MagicBytesValidator/Models/FileByteFilter.cs
@@ -2,7 +2,7 @@ namespace MagicBytesValidator.Models;
 
 // TODO: currently Anywhere() doesnt support null bytes in Array
 
-public class FileByteFilter : IFileType
+public abstract class FileByteFilter : IFileType
 {
     private readonly List<ByteCheck> _neededByteChecks = [];
     private readonly List<ByteCheck[]> _oneOfEachByteChecks = [];
@@ -66,7 +66,7 @@ public class FileByteFilter : IFileType
 
             if (!found)
             {
-                return false;   
+                return false;
             }
         }
 

--- a/MagicBytesValidator/Services/Streams/IStreamFileTypeProvider.cs
+++ b/MagicBytesValidator/Services/Streams/IStreamFileTypeProvider.cs
@@ -17,11 +17,21 @@ public interface IStreamFileTypeProvider
     Task<IEnumerable<IFileType>> FindAllMatchesAsync(Stream stream, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Tries to determine an unambiguous <see cref="IFileType"/> that matches a given file stream.
-    /// Returns <see cref="IFileType"/> in case it's the only (registered) type that matches.
-    /// As soon as multiple file types match the file, null will be returned.
-    /// If no type matches, null will be returned.
+    /// Determines <see cref="IFileType"/>s that match a given file stream.
+    /// If the result contains both a base file type (such as <see cref="Formats.Zip"/>)
+    /// and a specific variant of this base (such as <see cref="Formats.Docx"/>, which is 
+    /// based on a zip archive), the base type will be omitted and only the specific type
+    /// is included as it is "closer" to the file content.
     /// </summary>
-    /// <returns>Only one matching (known) <see cref="IFileType"/> that matches.</returns>
+    Task<IEnumerable<IFileType>> FindCloseMatchesAsync(Stream stream, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Determines close <see cref="IFileType"/>s that match a given file stream and - if only
+    /// one file type matches - return this type or otherwise null. Note that, if a stream
+    /// matches both a base file type such as <see cref="Formats.Zip"/>) and a specific variant
+    /// of this base (such as <see cref="Formats.Docx"/>, the base type won't be taken into
+    /// account (as the specific type is "closer" to the file content).
+    /// See also <see cref="FindCloseMatchesAsync"/>.
+    /// </summary>
     Task<IFileType?> TryFindUnambiguousAsync(Stream stream, CancellationToken cancellationToken);
 }

--- a/MagicBytesValidator/Services/Streams/StreamFileTypeProvider.cs
+++ b/MagicBytesValidator/Services/Streams/StreamFileTypeProvider.cs
@@ -33,12 +33,16 @@ public class StreamFileTypeProvider : IStreamFileTypeProvider
         return _mapping.FileTypes.Where(fileType => fileType.Matches(streamBuffer));
     }
 
-    public async Task<IFileType?> TryFindUnambiguousAsync(Stream stream, CancellationToken cancellationToken)
+    public async Task<IEnumerable<IFileType>> FindCloseMatchesAsync(Stream stream, CancellationToken cancellationToken)
     {
         var matches = (await FindAllMatchesAsync(stream, cancellationToken)).ToList();
 
-        return matches.Count == 1
-            ? matches.First()
-            : null;
+        return matches.Where(m1 =>
+            matches.All(m2 => !m2.GetType().IsSubclassOf(m1.GetType())));
+    }
+
+    public async Task<IFileType?> TryFindUnambiguousAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        return (await FindCloseMatchesAsync(stream, cancellationToken)).FirstOrDefault();
     }
 }


### PR DESCRIPTION
As shown in #137, if a DOCX file stream is validated, it matches both DOCX and ZIP (which it depends on), resulting in `TryFindUnambiguousAsync` being kinda wrong. In almost every case, we want the DOCX type and not the ZIP type. Therefore, I've added `FindCloseMatchesAsync`, which filters found parent types. `TryFindUnambiguousAsync` will make use of this. (Breaking change!) For this to work every time, I had to make `FileByteFilter` abstract so that you can't work with "anonymous" file types (which would always be filtered out by any other file type class). (Breaking change!) I also had to update almost all the test cases.